### PR TITLE
Made chariz buildable from scratch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "UXKit"]
 	path = headers/UXKit
-	url = git@github.com:hbang/UXKit-Headers.git
+	url = https://github.com/hbang/UXKit-Headers
 [submodule "cpm"]
 	path = cpm
-	url = git@github.com:CharizTeam/cpm.git
+	url = https://github.com/CharizTeam/cpm

--- a/README.md
+++ b/README.md
@@ -1,4 +1,18 @@
 # ![Chariz](https://i.imgur.com/BWTtsMO.png)
 A package manager for OS X.
 
+## Building
+Building Chariz requires [CocoaPods](https://cocoapods.org/). Install it with `sudo gem install cocoapods` before following the instructions below.
+
+```
+$ git clone --recursive https://github.com/CharizTeam/Chariz
+$ cd Chariz
+$ pod install
+$ xcodebuild -project cpm/cpm/external/fmdb/fmdb.xcodeproj -alltargets -configuration Debug
+$ xcodebuild -project cpm/cpm.xcodeproj -alltargets -configuration Debug
+```
+Then open the `Chariz.xcworkspace` (xcworkspace, not xcodeproj) file and the project will build and run.
+
+
+
 License: [GNU GPL v2](https://www.gnu.org/licenses/gpl-2.0.html)


### PR DESCRIPTION
Fixed the submodule links & updated the cpm module so chariz can be built from a fresh clone of the repo. Also added instructions in the readme about how to build it.