### PR TITLE
Fix constraint error

### DIFF
--- a/Chariz/CHRSourcesViewController.m
+++ b/Chariz/CHRSourcesViewController.m
@@ -19,7 +19,6 @@
 	
 	NSSplitView *splitView = [[NSSplitView alloc] initWithFrame:self.view.bounds];
 	splitView.autoresizingMask = UXViewAutoresizingFlexibleWidth | UXViewAutoresizingFlexibleHeight;
-	splitView.vertical = YES;
 	splitView.dividerStyle = NSSplitViewDividerStyleThin;
 	[self.view addSubview:splitView];
 	


### PR DESCRIPTION
Not sure if it happens on Yosemite, but in El Capitan the sources view is crashing the app because of faulty constraints.